### PR TITLE
Add Entity and ticking

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -8,6 +8,4 @@ PIXI.utils.sayHello(type);
 const app = new PIXI.Application({ width: 256, height: 256 });
 document.body.appendChild(app.view);
 
-const socket = new WebSocket("ws:///api/ws");
-const ses = new session.Session();
-new ws.Client(socket, ses);
+const ses = session.Connect();

--- a/public/js/session.js
+++ b/public/js/session.js
@@ -1,4 +1,12 @@
 import * as map from "/public/js/common/map.js";
+import * as ws from "/public/js/common/wsclient.js";
+
+export function Connect(url = "ws:///api/ws") {
+    const socket = new WebSocket(url);
+    const session = new Session();
+    const wrapped = new ws.Client(socket, session);
+    return wrapped;
+}
 
 export class Session {
     state;

--- a/src/anticheat.bak/position_validator.ts
+++ b/src/anticheat.bak/position_validator.ts
@@ -32,6 +32,7 @@ export class PositionValidator {
     readonly allowedBlocks: Set<Block>;
 
     private violations = 0;
+    // TODO: move this out
     private lastPositions: Position[] = [];
     private timeoutHandle: number | null = null;
 

--- a/src/common/entity.ts
+++ b/src/common/entity.ts
@@ -1,0 +1,33 @@
+import { Block, Position, Velocity } from "/src/common/types.ts";
+
+export class Entity {
+    readonly block: Block;
+    readonly initialPosition: Position;
+
+    position: Position;
+    velocity: Velocity;
+
+    constructor(block: Block, pos: Position) {
+        this.block = block;
+        this.position = pos;
+        this.velocity = { x: 0, y: 0 };
+        this.initialPosition = pos;
+    }
+
+    tick() {}
+}
+
+// PhysicsEntity is an Entity that is affected by gravity. The physics engine
+// uses it to apply gravity using a mass multiplier.
+export class PhysicsEntity extends Entity {
+    constructor(block: Block, pos: Position, readonly mass: number) {
+        super(block, pos);
+    }
+}
+
+// Player is a player entity.
+export class Player extends PhysicsEntity {
+    constructor(block: Block, pos: Position) {
+        super(block, pos, 1);
+    }
+}

--- a/src/common/types_validator.ts
+++ b/src/common/types_validator.ts
@@ -54,8 +54,8 @@ export function ValidateEvent(v: any): t.Event {
             ValidateVictoryEvent(v);
             break;
         }
-        case "CORRECTION": {
-            ValidateCorrectionEvent(v);
+        case "ENTITY_MOVE": {
+            ValidateEntityMoveEvent(v);
             break;
         }
         case undefined: {
@@ -108,24 +108,31 @@ export function ValidateVictoryEvent(v: any): t.VictoryEvent {
     if (v.type !== "VICTORY") throw new ValidationError("missing v.type");
     if (v.d === undefined) throw new ValidationError("missing v.d");
     if (typeof v.d.level !== "number") throw new ValidationError("missing v.d.level");
-    if (typeof v.d.time !== "number") throw new ValidationError("missing v.d.time");
+    if (v.d.time === undefined) throw new ValidationError("missing v.d.time");
 
     return v as t.VictoryEvent;
 }
 
-// ValidateCorrectionEvent validates the needed type constraints
-// from v and cast it to CorrectionEvent.
-export function ValidateCorrectionEvent(v: any): t.CorrectionEvent {
-    if (v.type !== "CORRECTION") throw new ValidationError("missing v.type");
-    if (v.d === undefined) throw new ValidationError("missing v.d");
-    if (!(v.d.position === undefined)) {
-        ValidatePosition(v.d.position);
-    }
-    if (!(v.d.velocity === undefined)) {
-        ValidateVelocity(v.d.velocity);
-    }
+// ValidateEntityPositionData validates the needed type constraints
+// from v and cast it to EntityPositionData.
+export function ValidateEntityPositionData(v: any): t.EntityPositionData {
+    if (v.initial === undefined) throw new ValidationError("missing v.initial");
+    ValidatePosition(v.initial);
+    if (v.position === undefined) throw new ValidationError("missing v.position");
+    ValidatePosition(v.position);
 
-    return v as t.CorrectionEvent;
+    return v as t.EntityPositionData;
+}
+
+// ValidateEntityMoveEvent validates the needed type constraints
+// from v and cast it to EntityMoveEvent.
+export function ValidateEntityMoveEvent(v: any): t.EntityMoveEvent {
+    if (v.type !== "ENTITY_MOVE") throw new ValidationError("missing v.type");
+    if (v.d === undefined) throw new ValidationError("missing v.d");
+    if (typeof v.d.level !== "number") throw new ValidationError("missing v.d.level");
+    if (typeof v.d.entities !== "object") throw new ValidationError("missing v.d.entities");
+
+    return v as t.EntityMoveEvent;
 }
 
 // ValidateCommand validates the needed type constraints

--- a/src/levels/01.ts
+++ b/src/levels/01.ts
@@ -1,4 +1,5 @@
-import { BlockPosition, MapMetadata } from "/src/common/types.ts";
+import { BlockPosition, MapMetadata, Position } from "/src/common/types.ts";
+import * as entity from "/src/common/entity.ts";
 import * as level from "/src/level.ts";
 import * as map from "/src/common/map.ts";
 
@@ -7,7 +8,7 @@ const rawMap = `
                                 LLLLLLLL
                                 LLLLLLLLL
                                   LLLLL
-                                   WW                       g
+                    B              WW                       g
                                    WW                       g
         P                          WW                       G
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,15 +58,14 @@ const metadata: MapMetadata = {
         "g": "",
     },
     entities: {
-        "P": "player[1-4]", // handle this in the engine
+        "P": "player", // handle this in the engine
+        "B": "ball",
     },
     blockMods: {
         "G": ["air", "goal", "fixed"],
         "g": ["air", "goal"],
     },
-    attributes: {
-        n_jumps: 3,
-    },
+    attributes: {},
 };
 
 const levelMap = new map.Map(rawMap, metadata);
@@ -73,5 +73,7 @@ const levelMap = new map.Map(rawMap, metadata);
 export class Level extends level.Level {
     constructor(s: level.Session) {
         super(s, levelMap, 1);
+        this.initializeEntity("P", (pos: Position) => new entity.Player("P", pos));
+        this.initializeEntity("B", (pos: Position) => new entity.PhysicsEntity("B", pos, 0.5));
     }
 }


### PR DESCRIPTION
This commit adds a new class Entity along with variants of it, such as PhysicsEntity. This is defined in common/entity.ts.

It also adds server ticking, which is handled by a level.Level. Ticking will help the server calculate physics in a more trivial manner (compared to tickless systems).

This comes with modifications to the types that are transferred over the Websocket. More specifically, instead of a single "correction" event for the player, the server can now correct multiple or all entities in a map. The client is expected to lerp the positions to make everything smooth while not having a physics engine of its own.

This commit also moves the anticheat code to a .bak folder to indicate that it's not yet ready. It shall be revisited at a later time when the physice engine's API is finalized.